### PR TITLE
Attempt to fix NLB stickiness issue

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -309,6 +309,7 @@ resource "aws_lb_target_group" "network" {
     protocol            = "${var.health_check_protocol}"
     timeout             = "6" # "${var.health_check_timeout}"
   }
+  stickiness = []
   tags     = "${module.label.tags}"
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
TF v1.10.0 complains stickiness for NLB is set when it is not. One possible workaround is setting it.